### PR TITLE
Fix LAYERSERIES_COMPAT warning on sumo branch

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,3 +12,5 @@ BBFILE_PRIORITY_up-board = "6"
 LAYERDEPENDS_up-board = "intel"
 
 BBMASK += "meta-virtualization/recipes-extended/iasl/iasl_20160527.bb"
+
+LAYERSERIES_COMPAT_up-board = "sumo"


### PR DESCRIPTION
Avoid unnecessary warning during bitbake build.

LAYERSERIES_COMPAT lists the versions of OE-CORE for which a layer is compatible.
See https://yoctoproject.org/docs/2.5.3/ref-manual/ref-manual.html#var-LAYERSERIES_COMPAT