### PR TITLE
Prevent the warning that LAYERSERIES_COMPAT_ should be set

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,3 +12,5 @@ BBFILE_PRIORITY_up-board = "6"
 LAYERDEPENDS_up-board = "intel"
 
 BBMASK += "meta-virtualization/recipes-extended/iasl/iasl_20160527.bb"
+
+LAYERSERIES_COMPAT_up-board = "warrior"


### PR DESCRIPTION
If not set, the warning

WARNING: Layer up-board should set LAYERSERIES_COMPAT_up-board in its conf/layer.conf file to list the core layer names it is compatible with.

will pop up during bitbake.